### PR TITLE
Add dark mode option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -87,10 +87,10 @@ ipcRenderer.on('menu-clicked', (e, arg) => {
       break;
     case 'Match System':
       ipcRenderer.send('match-system');
-      break
+      break;
     case 'Toggle Dark Mode':
       ipcRenderer.send('toggle-dark-mode');
-      break
+      break;
     default:
       break;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -86,10 +86,10 @@ ipcRenderer.on('menu-clicked', (e, arg) => {
       if (debugging) ipcRenderer.send('stop-debug');
       break;
     case 'Match System':
-      //TODO
+      ipcRenderer.send('match-system');
       break
     case 'Toggle Dark Mode':
-      //TODO
+      ipcRenderer.send('toggle-dark-mode');
       break
     default:
       break;

--- a/src/index.js
+++ b/src/index.js
@@ -85,6 +85,12 @@ ipcRenderer.on('menu-clicked', (e, arg) => {
     case 'Stop Debug':
       if (debugging) ipcRenderer.send('stop-debug');
       break;
+    case 'Match System':
+      //TODO
+      break
+    case 'Toggle Dark Mode':
+      //TODO
+      break
     default:
       break;
   }

--- a/src/main.js
+++ b/src/main.js
@@ -40,6 +40,7 @@ function createWindow() {
   const menu = require('./menu');
   Menu.setApplicationMenu(menu);
   require('./debug');
+  require('./theme');
   const title = require('./title');
 
   win.on('close', (e) => {

--- a/src/menu.js
+++ b/src/menu.js
@@ -110,9 +110,11 @@ let template = [
     label: 'Theme',
     submenu: [{
       label: 'Match System',
+      type: 'radio',
       click: () => menuClicked('Match System')
     }, {
       label: 'Toggle Dark Mode',
+      type: 'radio',
       click: () => menuClicked('Toggle Dark Mode')
     }]
   }

--- a/src/menu.js
+++ b/src/menu.js
@@ -105,6 +105,16 @@ let template = [
       accelerator: 'ESC',
       click: () => menuClicked('Stop Debug')
     }]
+  },
+  {
+    label: 'Theme',
+    submenu: [{
+      label: 'Match System',
+      click: () => menuClicked('Match System')
+    }, {
+      label: 'Toggle Dark Mode',
+      click: () => menuClicked('Toggle Dark Mode')
+    }]
   }
 ];
 

--- a/src/style.css
+++ b/src/style.css
@@ -13,31 +13,31 @@ html {
 
 :root, :root.light {
   --color-main-bg: #eee;
-  --color-main-fg: #000;
   --color-text-area: #fff;
   --color-text-area-r: #f8f8f8;
   --color-text: #000;
   --color-canvas-bg: #bbb;
+  --color-dialog-bg: #fff;
 }
 
 /* keep this dark root and 'root.dark' below in sync */
 @media (prefers-color-scheme: dark) {
   :root {
     --color-main-bg: #121212;
-    --color-main-fg: #fff;
     --color-text-area: #222222;
     --color-text-area-r: #222222;
     --color-text: #fff;
     --color-canvas-bg: #1e1e1e;
+    --color-dialog-bg: #333333;
   }
 }
 :root.dark {
   --color-main-bg: #222222;
-  --color-main-fg: #fff;
   --color-text-area: #121212;
   --color-text-area-r: #121212;
   --color-text: #fff;
   --color-canvas-bg: #292A2D;
+  --color-dialog-bg: #333333;
 }
 
 body {
@@ -69,7 +69,7 @@ body {
   flex-grow: 1;
   display: flex;
   background-color: var(--color-main-bg, #eee);
-  color: var(--color-main-fg, #000);
+  color: var(--color-text, #000);
 }
 
 #toolPane {
@@ -266,6 +266,8 @@ dialog {
   border: solid 1px #aaa;
   border-radius: 6px;
   box-shadow: 0 4px 8px #0004;
+  background-color: var(--color-dialog-bg, #fff);
+  color: var(--color-text, #000);
 }
 
 dialog section{
@@ -279,4 +281,11 @@ dialog p{
 
 dialog button{
   padding: 8px;
+  background-color: var(--color-dialog-bg, #fff);
+  color: var(--color-text, #000);
+}
+
+input[type="number"]{
+  background-color: var(--color-text-area, #fff);
+  color: var(--color-text, #000);
 }

--- a/src/style.css
+++ b/src/style.css
@@ -11,7 +11,7 @@ html {
   font-size: 62.5%;
 }
 
-:root, :root.light {
+:root {
   --color-main-bg: #eee;
   --color-text-area: #fff;
   --color-text-area-r: #f8f8f8;
@@ -20,7 +20,6 @@ html {
   --color-dialog-bg: #fff;
 }
 
-/* ! keep this 'root' and 'root.dark' below in sync */
 @media (prefers-color-scheme: dark) {
   :root {
     --color-main-bg: #121212;
@@ -30,14 +29,6 @@ html {
     --color-canvas-bg: #1e1e1e;
     --color-dialog-bg: #333333;
   }
-}
-:root.dark {
-    --color-main-bg: #121212;
-    --color-text-area: #222222;
-    --color-text-area-r: #222222;
-    --color-text: #fff;
-    --color-canvas-bg: #1e1e1e;
-    --color-dialog-bg: #333333;
 }
 
 body {
@@ -92,10 +83,9 @@ body {
   padding: 2px;
   min-width: 68px;
   height: 68px;
-  border: 1px solid gray;
-  color: #000;
+  color: #fff;
   text-align: center;
-  text-shadow: 0 0 10px #fff, -1px -1px 0 #fff, 1px -1px 0 #fff, -1px 1px 0 #fff, 1px 1px 0 #fff;
+  text-shadow: 0 0 10px #000, -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
   /* -webkit-text-stroke: 1px #000; */
   /* font-size: 1.05rem; */
   font-weight: 600;

--- a/src/style.css
+++ b/src/style.css
@@ -14,18 +14,30 @@ html {
 :root, :root.light {
   --color-main-bg: #eee;
   --color-main-fg: #000;
+  --color-text-area: #fff;
+  --color-text-area-r: #f8f8f8;
+  --color-text: #000;
+  --color-canvas-bg: #bbb;
 }
 
 /* keep this dark root and 'root.dark' below in sync */
 @media (prefers-color-scheme: dark) {
   :root {
-    --color-main-bg: #222222;
+    --color-main-bg: #121212;
     --color-main-fg: #fff;
+    --color-text-area: #222222;
+    --color-text-area-r: #222222;
+    --color-text: #fff;
+    --color-canvas-bg: #1e1e1e;
   }
 }
 :root.dark {
   --color-main-bg: #222222;
   --color-main-fg: #fff;
+  --color-text-area: #121212;
+  --color-text-area-r: #121212;
+  --color-text: #fff;
+  --color-canvas-bg: #292A2D;
 }
 
 body {
@@ -127,7 +139,7 @@ body {
   margin: 4px;
   flex-grow: 2;
   overflow: auto;
-  background-color: #bbb;
+  background-color: var(--color-canvas-bg, #bbb);
   border: 1px solid;
 }
 
@@ -211,15 +223,17 @@ body {
   width: 100%;
   height: 100%;
   resize: none;
-  border: solid 1px #aaa;
+  /* border: solid 1px #aaa; */
   cursor: auto;
   font-family: Monaco, Menlo, "Ubuntu Mono", Consolas, source-code-pro, monospace;
   font-size: 1.4rem;
   user-select: text;
+  background-color: var(--color-text-area, #fff);
+  color: var(--color-text, #000);
 }
 
 .text-area:read-only {
-  background-color: #f8f8f8;
+  background-color: var(--color-text-area-r, #f8f8f8);
 }
 
 footer {

--- a/src/style.css
+++ b/src/style.css
@@ -20,7 +20,7 @@ html {
   --color-dialog-bg: #fff;
 }
 
-/* keep this dark root and 'root.dark' below in sync */
+/* ! keep this 'root' and 'root.dark' below in sync */
 @media (prefers-color-scheme: dark) {
   :root {
     --color-main-bg: #121212;
@@ -32,12 +32,12 @@ html {
   }
 }
 :root.dark {
-  --color-main-bg: #222222;
-  --color-text-area: #121212;
-  --color-text-area-r: #121212;
-  --color-text: #fff;
-  --color-canvas-bg: #292A2D;
-  --color-dialog-bg: #333333;
+    --color-main-bg: #121212;
+    --color-text-area: #222222;
+    --color-text-area-r: #222222;
+    --color-text: #fff;
+    --color-canvas-bg: #1e1e1e;
+    --color-dialog-bg: #333333;
 }
 
 body {

--- a/src/style.css
+++ b/src/style.css
@@ -11,6 +11,23 @@ html {
   font-size: 62.5%;
 }
 
+:root, :root.light {
+  --color-main-bg: #eee;
+  --color-main-fg: #000;
+}
+
+/* keep this dark root and 'root.dark' below in sync */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-main-bg: #222222;
+    --color-main-fg: #fff;
+  }
+}
+:root.dark {
+  --color-main-bg: #222222;
+  --color-main-fg: #fff;
+}
+
 body {
   width: 100%;
   height: 100%;
@@ -39,7 +56,8 @@ body {
   min-height: 1px;
   flex-grow: 1;
   display: flex;
-  background-color: #eee;
+  background-color: var(--color-main-bg, #eee);
+  color: var(--color-main-fg, #000);
 }
 
 #toolPane {

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const {
+  ipcMain, nativeTheme
+} = require('electron');
+
+const toggleDarkMode = () => {
+  // If theme is currently dark
+  if (nativeTheme.shouldUseDarkColors) {
+    nativeTheme.themeSource = 'light';
+  } else {
+    nativeTheme.themeSource = 'dark';
+  }
+}
+
+ipcMain.on('match-system', () => {
+  nativeTheme.themeSource = 'system';
+});
+
+ipcMain.on('toggle-dark-mode', () => {
+  toggleDarkMode();
+});

--- a/src/theme.js
+++ b/src/theme.js
@@ -11,7 +11,7 @@ const toggleDarkMode = () => {
   } else {
     nativeTheme.themeSource = 'dark';
   }
-}
+};
 
 ipcMain.on('match-system', () => {
   nativeTheme.themeSource = 'system';


### PR DESCRIPTION
This PR adds (automatic and toggleable) dark mode!

Example:
> This is changed in-app via the 'Theme' menu option.

![pietron_screenshot_Dark](https://user-images.githubusercontent.com/78385048/206067505-52e1af05-c099-48bd-866d-f6403028f9ad.png)

### Note: Original light theme is still maintained
Details:
* Upon startup, default theme ('match system') matches the system preference of light vs dark.
    * Will change in sync if the system preferences do.
* Can also manually toggle between light and dark themes.
