### PR TITLE
Fix #24: In(n)

### DIFF
--- a/src/debug.js
+++ b/src/debug.js
@@ -218,8 +218,8 @@ const advanceDebug = () => {
           }
         case 14:
           { //in(n)
-            // Match first num in string (only if at first index)
-            const num = input.match(/^\d+/u);
+            // Match num at start of string, capture trailing whitespace
+            const num = input.match(/^\d+\s*/u);
             // If a number was found, remove it from the input string
             if (num) {
               input = input.slice(num[0].length);
@@ -227,7 +227,7 @@ const advanceDebug = () => {
               // No num, either empty or char not a digit, thus ignore cmd
               break;
             }
-            stack.push(num[0]);
+            stack.push(parseInt(num[0]));
             break;
           }
         case 15:

--- a/src/debug.js
+++ b/src/debug.js
@@ -218,15 +218,16 @@ const advanceDebug = () => {
           }
         case 14:
           { //in(n)
-            const temp = input.trimLeft().split(/\s+/u);
-            if (temp[0] === '') {
+            // Match first num in string (only if at first index)
+            const num = input.match(/^\d+/u);
+            // If a number was found, remove it from the input string
+            if (num) {
+              input = input.slice(num[0].length);
+            } else {
+              // No num, either empty or char not a digit, thus ignore cmd
               break;
             }
-            const num = parseInt(temp[0], 10);
-            if (!isNaN(num)) {
-              stack.push(num);
-              input = input.slice(input.indexOf(temp[0]) + temp[0].length);
-            }
+            stack.push(num);
             break;
           }
         case 15:

--- a/src/debug.js
+++ b/src/debug.js
@@ -227,7 +227,7 @@ const advanceDebug = () => {
               // No num, either empty or char not a digit, thus ignore cmd
               break;
             }
-            stack.push(num);
+            stack.push(num[0]);
             break;
           }
         case 15:

--- a/src/debug.js
+++ b/src/debug.js
@@ -218,8 +218,8 @@ const advanceDebug = () => {
           }
         case 14:
           { //in(n)
-            // Match num at start of string, capture trailing whitespace
-            const num = input.match(/^\d+\s*/u);
+            // Match num at start of string, capture leading whitespace and sign
+            const num = input.match(/^\s*[+-]?\d+/u);
             // If a number was found, remove it from the input string
             if (num) {
               input = input.slice(num[0].length);


### PR DESCRIPTION
This PR fixes issue #24 

### New In(n) behavior examples:
Input (pre): "2-4,6-8 2-3,4-5"
Stack: 2
Input (post): "-4,6-8 2-3,4-5"

Input (pre): "21-4, 6-8"
Stack: 21
Input (post): "-4, 6-8"

Input (pre): "2 4"
Stack: 2
Input (post): "4"

Input (pre): "a5"
Stack: N/A - no int, ignore cmd